### PR TITLE
Add bits to run this as a GitHub action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# Container image that runs your code
+FROM ruby:2.7
+ADD src/ /verticellis/
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'VerticEllis'
+description: 'Use VerticEllis to create/update a GitHub pages site'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd master
+
+ruby /verticellis/main.rb


### PR DESCRIPTION
This change adds configuration so this can be run as a GitHub action.

I've tried it out with a test site at https://github.com/nickh/shiny-giggle using this workflow:

<details>
<summary>Workflow File</summary>

```
# This is a basic workflow to help you get started with Actions

name: Build and Deploy to GitHub Pages

# Controls when the action will run. Triggers the workflow on push or pull request
# events but only for the master branch
on:
  push:
    branches: [ master ]

# A workflow run is made up of one or more jobs that can run sequentially or in parallel
jobs:
  # This workflow contains a single job called "build"
  build-and-deploy:
    # The type of runner that the job will run on
    runs-on: ubuntu-latest

    # Steps represent a sequence of tasks that will be executed as part of the job
    steps:
      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
      - name: Checkout
        uses: actions/checkout@v2
        with:
          path: 'master'
          
      # Build static content into public/
      - name: Build static site
        uses: nickh/verticellis@v1

      # Publish the updated static content to pages
      - name: Push static site
        uses: peaceiris/actions-gh-pages@v3
        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./master/public
```
</details>

When I commit changes to the `shiny-giggle` content and push to GitHub, the action runs verticellis to update the content and pushes it to pages. It would be straightforward to change the last step to publish elsewhere for sites not hosted on GitHub pages.